### PR TITLE
Grant Zuul'khan's spore immunity via a skill

### DIFF
--- a/created/json/conversationlist_fungi_panic.json
+++ b/created/json/conversationlist_fungi_panic.json
@@ -1483,6 +1483,11 @@
                 "rewardType":"actorCondition",
                 "rewardID":"spore_poison",
                 "value":-99
+            },
+            {
+                "rewardType":"skillIncrease",
+                "rewardID":"sporeImmunity",
+                "value":1
             }
         ]
     },


### PR DESCRIPTION
Note that this must be included only after the skill implementation in the game engine is merged (https://github.com/NutAndor/andors-trail/pull/45)